### PR TITLE
Fix: Add missing Recast.js library

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             touch-action: none;
         }
     </style>
+    <script src="https://cdn.babylonjs.com/recast.js"></script>
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
     <script src="https://cdn.babylonjs.com/gui/babylon.gui.min.js"></script>


### PR DESCRIPTION
The application was failing to load due to a missing Recast.js dependency, resulting in a "Recast is not defined" error.

This commit adds the Recast.js library via CDN to `index.html` to resolve the error and allow the Babylon.js scene to load correctly. The script tag for recast.js has been placed before babylon.js.

Output: