### PR TITLE
Integrate Babylon.js laser effect into scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,22 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <title>Babylon.js Site</title>
-    <style>
-        html, body {
-            overflow: hidden;
-            width: 100%;
-            height: 100%;
-            margin: 0;
-            padding: 0;
-        }
-        #renderCanvas {
-            width: 100%;
-            height: 100%;
-            touch-action: none;
-        }
-    </style>
+    <link rel="stylesheet" href="stryle.css">
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
+    <script src="https://cdn.babylonjs.com/gui/babylon.gui.min.js"></script>
 </head>
 <body>
     <canvas id="renderCanvas"></canvas>


### PR DESCRIPTION
This commit introduces an interactive laser effect into the Babylon.js application.

Key changes:
- I added laser global variables, the core `updateLaserLineGeometryBabylon` function for raycasting and bounces, and laser initialization logic to `script.js`.
- I modified the `createScene` function in `script.js`:
    - I integrated new lighting (ambient, directional with gizmo, two spotlights parented to the model).
    - I updated camera parameters for different interaction style (FOV, sensibility, etc.), while preserving the existing model-based camera targeting and framing logic.
    - The existing model (`HoodedCory_NewStart_NewHood_DecimatedCreasedHood-1.glb`) is now used to define `interactiveMeshes` for laser collision.
    - I removed the previous skybox and an old spotlight.
- I updated the main render loop in `script.js` to calculate laser positions/directions based on camera orientation and call the laser update function.
- I made `createScene` asynchronous to accommodate `ImportMeshAsync`.
- I modified `index.html` to include the `babylon.gui.min.js` library (required for light gizmos) and link to `stryle.css`.
- I verified and ensured `stryle.css` has the correct styles.

The `adjustCameraForModel` function and its associated calls were explicitly excluded from this integration as per your feedback. The existing model loading mechanism and camera setup logic were preserved and built upon.