### PR TITLE
feat: Implement rave-lasers-1 functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,6 +7,164 @@ const laserOffset2 = new BABYLON.Vector3(0.8, 0.8, -1);
 const laserOffset3 = new BABYLON.Vector3(-0.8, -0.8, -1);
 const laserOffset4 = new BABYLON.Vector3(0.8, -0.8, -1);
 
+let laserPulseStates = [
+    { isPulsing: false, pulseOriginalColor: null, pulseCurrentColor: null },
+    { isPulsing: false, pulseOriginalColor: null, pulseCurrentColor: null },
+    { isPulsing: false, pulseOriginalColor: null, pulseCurrentColor: null },
+    { isPulsing: false, pulseOriginalColor: null, pulseCurrentColor: null }
+];
+
+let laserAngleStates = [
+    { originalDirection: null, customDirection: null, isCustomActive: false },
+    { originalDirection: null, customDirection: null, isCustomActive: false },
+    { originalDirection: null, customDirection: null, isCustomActive: false },
+    { originalDirection: null, customDirection: null, isCustomActive: false }
+];
+
+// Structure for laserEffectTimers, to be initialized properly later.
+// Example: { strobeTimer: 0, strobeInterval: 0, angleChangeTimer: 0, angleChangeInterval: 0, originalColor: null, baseDirection: null }
+let laserEffectTimers = [null, null, null, null]; // Will be populated by raveLasers1 setup
+
+// Standard laser color - this should ideally be sourced from a single definition.
+// For now, raveLasers1 will use this to create the Color4.
+const DEFAULT_LASER_COLOR_RGB = new BABYLON.Color3(1, 0, 0); // Red
+
+// Corresponds to the conceptual "laserpulserate1-"
+async function laserPulseRate1(laserIndex, originalColor) {
+    if (laserIndex === undefined || laserIndex < 0 || laserIndex >= 4) { // Assuming 4 lasers based on laserOffsets and laserLines
+        console.error("laserPulseRate1: Invalid laserIndex provided:", laserIndex);
+        return;
+    }
+    if (!originalColor || !(originalColor instanceof BABYLON.Color4)) {
+        console.error("laserPulseRate1: Valid originalColor (BABYLON.Color4) not provided for laser:", laserIndex);
+        return;
+    }
+
+    const state = laserPulseStates[laserIndex];
+    if (state.isPulsing) {
+        // console.log(`Laser ${laserIndex} is already pulsing.`);
+        return; // Already pulsing, prevent re-triggering
+    }
+
+    state.isPulsing = true;
+    state.pulseOriginalColor = originalColor.clone(); // Store the color to return to
+    state.pulseCurrentColor = originalColor.clone();   // Start with original color visible
+
+    const offColor = new BABYLON.Color4(0, 0, 0, 0); // Transparent black for "off"
+    const pulseCount = 3;    // Number of off/on cycles in one strobe effect
+    const onDuration = 70;   // Milliseconds for the "on" part of a pulse blink
+    const offDuration = 70;  // Milliseconds for the "off" part of a pulse blink
+
+    for (let i = 0; i < pulseCount; i++) {
+        // Set to OFF color state
+        state.pulseCurrentColor = offColor;
+        // The main render loop calling updateLaserLineGeometryBabylon will use this state.
+        await new Promise(resolve => setTimeout(resolve, offDuration));
+
+        // Set to ON color state (original)
+        state.pulseCurrentColor = state.pulseOriginalColor;
+        await new Promise(resolve => setTimeout(resolve, onDuration));
+    }
+
+    state.isPulsing = false;
+    // After pulsing, updateLaserLineGeometryBabylon will naturally use its default color logic
+    // for this laser, as state.isPulsing is now false.
+}
+
+// Corresponds to the conceptual "laseranglechange-1"
+function laserAngleChange1(laserIndex, baseDirection) {
+    if (laserIndex === undefined || laserIndex < 0 || laserIndex >= 4) {
+        console.error("laserAngleChange1: Invalid laserIndex provided:", laserIndex);
+        return;
+    }
+    if (!baseDirection || !(baseDirection instanceof BABYLON.Vector3) || baseDirection.lengthSquared() === 0) {
+        console.error("laserAngleChange1: Valid baseDirection (BABYLON.Vector3) not provided for laser:", laserIndex);
+        return; // Needs a valid direction vector
+    }
+
+    const state = laserAngleStates[laserIndex];
+    state.originalDirection = baseDirection.clone(); // Store the direction upon which this change is based
+
+    const maxAngleChangeDegrees = 35;
+    const maxAngleChangeRadians = BABYLON.Tools.ToRadians(maxAngleChangeDegrees);
+
+    // Generate random rotation angles for yaw and pitch (around Y and X axes relative to the vector's frame)
+    // This is a simplification. True yaw/pitch relative to the vector is more complex.
+    // A simpler approach: create a random rotation quaternion.
+
+    // Random axis for rotation (not perfectly uniform, but simple)
+    const randomAxis = BABYLON.Vector3.Random(-1, 1).normalize();
+
+    // Random angle within the allowed range
+    const randomAngle = (Math.random() * 2 - 1) * maxAngleChangeRadians; // between -maxAngleChangeRadians and +maxAngleChangeRadians
+
+    const rotationQuaternion = BABYLON.Quaternion.RotationAxis(randomAxis, randomAngle);
+
+    // Apply the rotation to the originalDirection
+    // The baseDirection should be the laser's current "neutral" or "intended" direction.
+    // If repeatedly called, it should base the new change on the *original* camera-targeted direction,
+    // not the previously randomized one, to prevent drift.
+    // So, `baseDirection` should always be the non-randomized, camera-target direction.
+    state.customDirection = baseDirection.clone(); // Start with the base direction
+    state.customDirection.rotateByQuaternionToRef(rotationQuaternion, state.customDirection); // Rotate it
+    state.customDirection.normalize(); // Ensure it's a unit vector
+
+    state.isCustomActive = true;
+    // The main laser update logic will need to check isCustomActive and use customDirection.
+    // This function itself doesn't run over time; it just sets the state once per call.
+}
+
+// Corresponds to the conceptual "rave-lasers-1"
+function raveLasers1(deltaTimeInSeconds, camera, worldLaserOrigins) {
+    if (!camera || !worldLaserOrigins || worldLaserOrigins.length !== 4) {
+        console.error("raveLasers1: Missing camera or worldLaserOrigins.");
+        return;
+    }
+
+    for (let i = 0; i < 4; i++) {
+        // Initialize timer state for each laser if not already done
+        if (!laserEffectTimers[i]) {
+            const randomStrobeInterval = Math.random() * 4 + 1; // 1 to 5 seconds
+            const randomAngleInterval = Math.random() * 4 + 1; // 1 to 5 seconds
+            laserEffectTimers[i] = {
+                strobeTimer: randomStrobeInterval,
+                strobeInterval: randomStrobeInterval,
+                angleChangeTimer: randomAngleInterval,
+                angleChangeInterval: randomAngleInterval,
+                originalColor: new BABYLON.Color4(DEFAULT_LASER_COLOR_RGB.r, DEFAULT_LASER_COLOR_RGB.g, DEFAULT_LASER_COLOR_RGB.b, 1),
+                // baseDirection will be updated each frame before angle change
+            };
+        }
+
+        const timerState = laserEffectTimers[i];
+
+        // Strobe Logic
+        timerState.strobeTimer -= deltaTimeInSeconds;
+        if (timerState.strobeTimer <= 0) {
+            laserPulseRate1(i, timerState.originalColor); // Call the strobe effect
+            timerState.strobeInterval = Math.random() * 4 + 1; // New interval: 1 to 5s
+            timerState.strobeTimer = timerState.strobeInterval;
+        }
+
+        // Angle Change Logic
+        timerState.angleChangeTimer -= deltaTimeInSeconds;
+        if (timerState.angleChangeTimer <= 0) {
+            const worldLaserOrigin = worldLaserOrigins[i];
+            if (worldLaserOrigin && camera.target) {
+                 // Calculate current default direction for this laser
+                const baseDirection = camera.target.subtract(worldLaserOrigin).normalize();
+                if (baseDirection.lengthSquared() > 0.001) {
+                    laserAngleChange1(i, baseDirection); // Call the angle change effect
+                } else {
+                    // console.warn(`Laser ${i}: Base direction is zero vector.`);
+                }
+            }
+            timerState.angleChangeInterval = Math.random() * 4 + 1; // New interval: 1 to 5s
+            timerState.angleChangeTimer = timerState.angleChangeInterval;
+        }
+    }
+}
+
 let laserLines = [];
 
 const MAX_LASER_LENGTH = 20;
@@ -69,10 +227,18 @@ function updateLaserLineGeometryBabylon(laserLineMesh, origin, direction, intera
         // console.log(`Laser ${laserIndex} points:`, points.map(p => `(${p.x.toFixed(2)}, ${p.y.toFixed(2)}, ${p.z.toFixed(2)})`).join(' -> '));
     }
 
-    const laserColor = new BABYLON.Color3(1,0,0);
+    let currentLaserColor; // This will be a Color4
+    const pulseState = laserPulseStates[laserIndex];
+
+    if (pulseState && pulseState.isPulsing && pulseState.pulseCurrentColor) {
+        currentLaserColor = pulseState.pulseCurrentColor;
+    } else {
+        // Default color, ensure DEFAULT_LASER_COLOR_RGB is accessible (it is global)
+        currentLaserColor = new BABYLON.Color4(DEFAULT_LASER_COLOR_RGB.r, DEFAULT_LASER_COLOR_RGB.g, DEFAULT_LASER_COLOR_RGB.b, 1);
+    }
     const lineColors = [];
     for(let k = 0; k < points.length; k++){
-        lineColors.push(laserColor.toColor4());
+        lineColors.push(currentLaserColor.clone()); // Use the determined Color4 object
     }
 
     laserLineMesh = BABYLON.MeshBuilder.CreateLines(laserLineMesh.name, {
@@ -259,32 +425,84 @@ createScene().then(result => {
 
     engine.runRenderLoop(() => {
         if (scene && scene.activeCamera) { // scene.activeCamera is 'camera'
+            const deltaTimeInSeconds = engine.getDeltaTime() / 1000.0;
             const camWorldMatrix = camera.getWorldMatrix();
-            // Ensure camera.target is correctly updated if it's dynamic, or use the one from camera object
-            const camTarget = camera.target.clone();
+            const camTarget = camera.target.clone(); // Use a stable clone of camera target
 
-            if (consoleLogSpamStopper < 5) {
+            if (consoleLogSpamStopper < 5) { // Keep console spam under control
                 if (interactiveMeshes.length === 0) {
-                    console.warn("WARNING: `interactiveMeshes` array is EMPTY. Lasers will not collide. Check model loading and population of this array.");
+                    console.warn("WARNING: `interactiveMeshes` array is EMPTY. Lasers will not collide or reflect.");
                 }
                 consoleLogSpamStopper++;
             }
 
+            const collectedWorldLaserOrigins = [];
+            const collectedFinalLaserDirections = [];
             const laserOffsets = [laserOffset1, laserOffset2, laserOffset3, laserOffset4];
+
+            // First pass: Calculate all laser origins and their intended/custom directions
+            for (let i = 0; i < laserLines.length; i++) {
+                const localOffset = laserOffsets[i];
+                const worldLaserOrigin = BABYLON.Vector3.TransformCoordinates(localOffset, camWorldMatrix);
+                collectedWorldLaserOrigins.push(worldLaserOrigin);
+
+                let finalLaserDirection;
+                // Calculate default direction towards camera target
+                const defaultDirection = camTarget.subtract(worldLaserOrigin).normalize();
+
+                // Check if a custom angle is active for this laser
+                if (laserAngleStates[i] && laserAngleStates[i].isCustomActive && laserAngleStates[i].customDirection && laserAngleStates[i].customDirection.lengthSquared() > 0.001) {
+                    finalLaserDirection = laserAngleStates[i].customDirection; // This should be a normalized vector
+                } else {
+                    finalLaserDirection = defaultDirection;
+                }
+
+                collectedFinalLaserDirections.push(finalLaserDirection);
+            }
+
+            // Call raveLasers1 to update laser effect states (strobing, new angle decisions)
+            // It uses collectedWorldLaserOrigins to calculate base directions for any new angle changes.
+            if (collectedWorldLaserOrigins.length === 4) {
+                raveLasers1(deltaTimeInSeconds, camera, collectedWorldLaserOrigins);
+            }
+
+            // Second pass: Update all laser line geometries based on calculated states
             for (let i = 0; i < laserLines.length; i++) {
                 if (!laserLines[i]) continue;
 
-                const localOffset = laserOffsets[i];
-                const worldLaserOrigin = BABYLON.Vector3.TransformCoordinates(localOffset, camWorldMatrix);
-                const laserDirection = camTarget.subtract(worldLaserOrigin).normalize();
+                const worldLaserOrigin = collectedWorldLaserOrigins[i];
+                const finalLaserDirection = collectedFinalLaserDirections[i];
 
-                if (worldLaserOrigin && laserDirection.lengthSquared() > 0.001 && interactiveMeshes.length > 0) {
-                   laserLines[i] = updateLaserLineGeometryBabylon(laserLines[i], worldLaserOrigin, laserDirection, interactiveMeshes, MAX_BOUNCES, MAX_LASER_LENGTH, scene, i);
-                } else if (interactiveMeshes.length === 0 && laserLines[i]) {
-                    const points = [worldLaserOrigin.clone(), worldLaserOrigin.add(laserDirection.scale(MAX_LASER_LENGTH))];
-                     const noHitLaserColor = new BABYLON.Color3(0,1,0); // Green if no model/hit
-                     const lineColors = [noHitLaserColor.toColor4(), noHitLaserColor.toColor4()];
-                     laserLines[i] = BABYLON.MeshBuilder.CreateLines(laserLines[i].name, {points: points, colors:lineColors, instance: laserLines[i], updatable: true}, scene);
+                // Ensure origin and a valid direction exist before updating
+                if (worldLaserOrigin && finalLaserDirection && finalLaserDirection.lengthSquared() > 0.001) {
+                    if (interactiveMeshes.length > 0) {
+                        laserLines[i] = updateLaserLineGeometryBabylon(laserLines[i], worldLaserOrigin, finalLaserDirection, interactiveMeshes, MAX_BOUNCES, MAX_LASER_LENGTH, scene, i);
+                    } else {
+                        // No reflection: Draw a simple line, but respect pulsing state for color
+                        const points = [worldLaserOrigin.clone(), worldLaserOrigin.add(finalLaserDirection.scale(MAX_LASER_LENGTH))];
+
+                        let noHitLaserColor;
+                        const pulseState = laserPulseStates[i];
+                        if (pulseState && pulseState.isPulsing && pulseState.pulseCurrentColor) {
+                            noHitLaserColor = pulseState.pulseCurrentColor; // Use pulsing color if active
+                        } else {
+                            noHitLaserColor = new BABYLON.Color4(0, 1, 0, 1); // Default green for no-hit
+                        }
+                        const lineColors = [noHitLaserColor.clone(), noHitLaserColor.clone()];
+                        laserLines[i] = BABYLON.MeshBuilder.CreateLines(laserLines[i].name, {points: points, colors: lineColors, instance: laserLines[i], updatable: true}, scene);
+                    }
+                } else if (laserLines[i] && worldLaserOrigin) {
+                    // If direction is invalid (e.g. zero vector), make the laser effectively invisible (zero length)
+                     let colorForZeroLengthLine;
+                     const pulseState = laserPulseStates[i];
+                     if (pulseState && pulseState.isPulsing && pulseState.pulseCurrentColor) {
+                        colorForZeroLengthLine = pulseState.pulseCurrentColor;
+                     } else {
+                        colorForZeroLengthLine = new BABYLON.Color4(DEFAULT_LASER_COLOR_RGB.r, DEFAULT_LASER_COLOR_RGB.g, DEFAULT_LASER_COLOR_RGB.b, 1);
+                     }
+                     const zeroLengthPoints = [worldLaserOrigin.clone(), worldLaserOrigin.clone()];
+                     const zeroLengthColors = [colorForZeroLengthLine.clone(),colorForZeroLengthLine.clone()];
+                    laserLines[i] = BABYLON.MeshBuilder.CreateLines(laserLines[i].name, {points: zeroLengthPoints, colors: zeroLengthColors, instance: laserLines[i], updatable: true}, scene);
                 }
             }
             scene.render();


### PR DESCRIPTION
Adds a new "rave-lasers-1" behavior to the scene's four lasers. This includes:

1.  **Strobing Effect (`laserPulseRate1`):**
    - Lasers now randomly strobe at intervals between 1 to 5 seconds.
    - The strobe consists of 3 rapid on/off blinks (70ms each phase).
    - Managed by `laserPulseRate1` function and `laserPulseStates`.

2.  **Random Angle Changes (`laserAngleChange1`):**
    - Lasers now randomly change their projection angle at intervals between 1 to 5 seconds.
    - The angle change is rapid and constrained to +/- 35 degrees from the laser's default camera-targeted direction.
    - Managed by `laserAngleChange1` function and `laserAngleStates`.

3.  **Orchestration (`raveLasers1`):**
    - The main `raveLasers1` function manages the timing and triggering of the strobe and angle change effects for each of the four lasers independently.
    - This function is called every frame from the render loop.

4.  **Integration:**
    - `updateLaserLineGeometryBabylon` was modified to use the dynamic color states from `laserPulseStates` for strobing.
    - The main render loop was updated to provide the correct, potentially custom, direction (from `laserAngleStates`) to `updateLaserLineGeometryBabylon`.
    - Lasers continue to originate from their camera-relative offsets and reflect off 3D model surfaces with their new dynamic behaviors.

The implementation ensures that these effects occur randomly and independently for each laser, enhancing the visual experience as per the issue requirements.